### PR TITLE
Fix home page's catalog link

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -15,7 +15,7 @@
         <a href="/concept">Learn more</a>,
         <a href="/community">get involved</a>,
         or browse or a
-        <a href="">catalog</a> of
+        <a href="/catalog">catalog</a> of
         modular components.
       </p>
     </div>


### PR DESCRIPTION
Currently, the catalog link in home page's body points back to the home page, instead of the catalog one. This PR tries to fix this.

Other than that, really nice project. I'll definitely be keeping an eye on this :)